### PR TITLE
Adds support for wildcard topics

### DIFF
--- a/lib/radiovis-server.js
+++ b/lib/radiovis-server.js
@@ -10,6 +10,7 @@ function RadioVisServer (settings, serviceData) {
   this.stompHost = settings.stompHost || '0.0.0.0'
   this.adminPort = settings.adminPort || 3000
   this.adminHost = settings.adminHost || '127.0.0.1'
+  this.wildcard = settings.wildcard || false;
 
   this.topicMap = {}
   this.connections = []
@@ -34,6 +35,16 @@ RadioVisServer.prototype.initTopicMap = function () {
         }
       }
     })
+  }
+
+  if (this.wildcard) {
+    server.topicMap['*'] = {
+      serviceId: '*',
+      subscribers: {
+        image: [],
+        text: []
+      }
+    }
   }
 }
 
@@ -134,6 +145,14 @@ RadioVisServer.prototype.publish = function (serviceId, type) {
       connection.publish(serviceId, topicId, type)
     })
   })
+  // if wildcard is configured, also dispatch to wildcard subscribers
+  if (this.wildcard) {
+    const [topicId] = service.topics() // only the first topic, to avoid duplication
+    const subscribers = this.topicMap['*'].subscribers[type]
+    subscribers.forEach(function (connection) {
+      connection.publish(serviceId, topicId, type)
+    })
+  }
 }
 
 RadioVisServer.prototype.start = function () {

--- a/lib/stomp/connection.js
+++ b/lib/stomp/connection.js
@@ -105,7 +105,7 @@ StompConnection.prototype.parseTopic = function (frame) {
   }
 
   // Verify the the topic is valid
-  const matches = destination.match(/^\/topic\/([/\w]+)\/(image|text)$/)
+  const matches = destination.match(/^\/topic\/([/\w]+|\*)\/(image|text)$/)
   if (!matches) {
     this.sendError('Invalid Topic Name')
     return
@@ -145,8 +145,17 @@ StompConnection.prototype.handleSubscribe = function (frame) {
     this.socket.write(receipt.toBuffer())
   }
 
-  // Send the current message to the client
-  this.publish(params.serviceId, params.topicId, params.type)
+  if (params.topicId !== '*') {
+    // Send the current message to the client
+    this.publish(params.serviceId, params.topicId, params.type)
+  } else {
+    const server = this
+    // Send the current message for all services to the client
+    Object.values(this.server.services).forEach(function (service) {
+      const [topicId] = service.topics()
+      server.publish(service.id, topicId, params.type)
+    })
+  }
 }
 
 StompConnection.prototype.handleUnsubscribe = function (frame) {

--- a/settings.js
+++ b/settings.js
@@ -20,5 +20,9 @@ module.exports = {
   // This can be useful to remove that clients have silently disappeared
   //
   // If you are sending messages frequently anyway, this will be ignored
-  republishFrequency: 900
+  republishFrequency: 900,
+
+  // to allow wildcard subscriptions (delivery of all messages published on any
+  // topic) set this to true
+  wildcard: true
 }

--- a/test/stomp/frame.js
+++ b/test/stomp/frame.js
@@ -64,6 +64,14 @@ describe('StompFrame', function () {
       const frame = new StompFrame('SUBSCRIBE', { destination: '/topic/fm/ce1/c201/09880/text', ack: 'auto' })
       assert.strictEqual(frame.toBuffer().toString(), 'SUBSCRIBE\x0Adestination:/topic/fm/ce1/c201/09880/text\x0Aack:auto\x0A\x0A\x00')
     })
+
+    it('should parse a wildcard subscription correctly', function () {
+      const buffer = Buffer.from('SUBSCRIBE\x0Adestination:/topic/*/text\x0Aack:auto\x0A\x0A\x00')
+      const frame = StompFrame.parse(buffer)
+      assert.strictEqual(frame.command, 'SUBSCRIBE')
+      assert.deepStrictEqual(frame.headers, { destination: '/topic/*/text', ack: 'auto' })
+      assert.strictEqual(frame.body, '')
+    })
   })
 
   describe('MESSAGE frame', function () {


### PR DESCRIPTION
Adding `wildcard: true` to `settings.js` means the server will accept subscriptions to `/topic/*/{type}` and they will receive messages of the requested type for any service.